### PR TITLE
remove calls to totient and add encoding/decoding

### DIFF
--- a/rsa.rkt
+++ b/rsa.rkt
@@ -2,7 +2,7 @@
 (require math/number-theory)
 (define (make-rsa p q pass)
   (define (make-e p q)
-  (- (* (- p 1) (- q 1)) 1))
+    (- (* (- p 1) (- q 1)) 1))
   (define public_key (cons (* p q) (make-e p q)))
   (define (encrypt num)
     (map (lambda (x)
@@ -28,4 +28,24 @@
           ((equal? m 'decrypt) (decrypt (car params) (cdr params)))
           ((equal? m 'passwd) (setpass (car params) (cdr params)))
           ((equal? m 'key) public_key)))
-  dispatch)
+  (if (and (prime? p) (prime? q))
+      dispatch
+      "ERROR: p and q must be prime"))
+
+;; helpers for string encryption
+(define encode
+  (lambda (s)
+    (string->number (foldl (lambda (a b)
+                             (string-append (~a (char->integer a) #:min-width 3 #:align 'right #:left-pad-string "0") b))
+                           ""
+                           (string->list s)))))
+(define (decode n)
+  (define (iter n result)
+    (let ((c (remainder n 1000)))
+      (if (= n 0)
+          result
+          (iter (quotient n 1000) (string-append
+                                   result
+                                   (list->string (list (integer->char c)))
+                                   )))))
+  (iter n ""))


### PR DESCRIPTION
The calls to totient took too long. I replaced them with the shortcut implementation only possible with the prime factors of n.
